### PR TITLE
Update to libpq 11.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,192 @@
+cmake_minimum_required(VERSION 3.5)
+project(libpq)
+
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif()
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+option(USE_OPENSSL "Build libpq with OpenSSL support" OFF)
+option(USE_ZLIB "Build libpq with zlib support" OFF)
+set(OPENSSL_DEFINE)
+if (USE_OPENSSL)
+    set(OPENSSL_DEFINE -DUSE_OPENSSL)
+endif()
+
+set(CMAKE_STATIC_LIBRARY_PREFIX)
+set(CMAKE_SHARED_LIBRARY_PREFIX)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+file(WRITE source_subfolder/src/port/pg_config_paths.h "#define PGBINDIR \"${CONAN_CMAKE_MODULE_PATH}/bin\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PGBINDIR \"${CONAN_CMAKE_MODULE_PATH}/bin\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PGSHAREDIR \"${CONAN_CMAKE_MODULE_PATH}/share/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define SYSCONFDIR \"${CONAN_CMAKE_MODULE_PATH}/etc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define INCLUDEDIR \"${CONAN_CMAKE_MODULE_PATH}/include\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PKGINCLUDEDIR \"${CONAN_CMAKE_MODULE_PATH}/include/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define INCLUDEDIRSERVER \"${CONAN_CMAKE_MODULE_PATH}/include/postgresql/server\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define LIBDIR \"${CONAN_CMAKE_MODULE_PATH}/lib\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PKGLIBDIR \"${CONAN_CMAKE_MODULE_PATH}/lib/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define LOCALEDIR \"${CONAN_CMAKE_MODULE_PATH}/share/locale\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define DOCDIR \"${CONAN_CMAKE_MODULE_PATH}/share/doc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define HTMLDIR \"${CONAN_CMAKE_MODULE_PATH}/share/doc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define MANDIR \"${CONAN_CMAKE_MODULE_PATH}/share/man\"\n")
+
+file(REMOVE
+    source_subfolder/src/include/pg_config.h
+    source_subfolder/src/include/pg_config_ext.h
+    source_subfolder/src/include/pg_config_os.h
+)
+
+configure_file(source_subfolder/src/include/pg_config.h.win32 include/pg_config.h)
+configure_file(source_subfolder/src/include/pg_config_ext.h.win32 include/pg_config_ext.h)
+configure_file(source_subfolder/src/include/port/win32.h include/pg_config_os.h)
+
+file(WRITE ${CMAKE_BINARY_DIR}/include/pg_config_paths.h "#define SYSCONFDIR \"\"")
+
+
+set(pg_port_src
+    source_subfolder/src/port/chklocale.c
+    source_subfolder/src/port/crypt.c
+    source_subfolder/src/port/dirent.c
+    source_subfolder/src/port/dirmod.c
+    source_subfolder/src/port/erand48.c
+    source_subfolder/src/port/fls.c
+    source_subfolder/src/port/fseeko.c
+    source_subfolder/src/port/getaddrinfo.c
+    source_subfolder/src/port/getopt.c
+    source_subfolder/src/port/getopt_long.c
+    source_subfolder/src/port/getpeereid.c
+    source_subfolder/src/port/getrusage.c
+    source_subfolder/src/port/gettimeofday.c
+    source_subfolder/src/port/inet_aton.c
+    source_subfolder/src/port/inet_net_ntop.c
+    source_subfolder/src/port/isinf.c
+    source_subfolder/src/port/kill.c
+    source_subfolder/src/port/mkdtemp.c
+    source_subfolder/src/port/noblock.c
+    source_subfolder/src/port/open.c
+    source_subfolder/src/port/path.c
+    source_subfolder/src/port/pg_crc32c_choose.c
+    source_subfolder/src/port/pg_crc32c_sb8.c
+    source_subfolder/src/port/pg_crc32c_sse42.c
+    source_subfolder/src/port/pg_strong_random.c
+    source_subfolder/src/port/pgcheckdir.c
+    source_subfolder/src/port/pgmkdirp.c
+    source_subfolder/src/port/pgsleep.c
+    source_subfolder/src/port/pgstrcasecmp.c
+    source_subfolder/src/port/pqsignal.c
+    source_subfolder/src/port/qsort.c
+    source_subfolder/src/port/qsort_arg.c
+    source_subfolder/src/port/quotes.c
+    source_subfolder/src/port/random.c
+    source_subfolder/src/port/rint.c
+    source_subfolder/src/port/snprintf.c
+    source_subfolder/src/port/sprompt.c
+    source_subfolder/src/port/srandom.c
+    source_subfolder/src/port/strlcat.c
+    source_subfolder/src/port/strlcpy.c
+    source_subfolder/src/port/system.c
+    source_subfolder/src/port/tar.c
+    source_subfolder/src/port/thread.c
+    source_subfolder/src/port/unsetenv.c
+    source_subfolder/src/port/win32env.c
+    source_subfolder/src/port/win32security.c
+    source_subfolder/src/port/win32setlocale.c
+)
+
+if (${MSVC_VERSION} GREATER 1800)
+    list(APPEND pg_port_src
+         source_subfolder/src/port/win32error.c)
+endif()
+
+include_directories(source_subfolder/src/include/port/win32 source_subfolder/src/include/port/win32_msvc)
+
+set(pg_backend_src
+    source_subfolder/src/common/base64.c
+    source_subfolder/src/common/config_info.c
+    source_subfolder/src/common/controldata_utils.c
+    source_subfolder/src/common/fe_memutils.c
+    source_subfolder/src/common/file_utils.c
+    source_subfolder/src/common/ip.c
+    source_subfolder/src/common/keywords.c
+    source_subfolder/src/common/md5.c
+    source_subfolder/src/common/pg_lzcompress.c
+    source_subfolder/src/common/pgfnames.c
+    source_subfolder/src/common/psprintf.c
+    source_subfolder/src/common/restricted_token.c
+    source_subfolder/src/common/rmtree.c
+    source_subfolder/src/common/saslprep.c
+    source_subfolder/src/common/scram-common.c
+    source_subfolder/src/common/sha2.c
+    source_subfolder/src/common/unicode_norm.c
+    source_subfolder/src/common/username.c
+    source_subfolder/src/common/wait_error.c
+    source_subfolder/src/backend/utils/mb/wchar.c
+    source_subfolder/src/backend/utils/mb/encnames.c
+)
+
+set(pg_libpq_src
+    source_subfolder/src/interfaces/libpq/fe-auth.c
+    source_subfolder/src/interfaces/libpq/fe-auth-scram.c
+    source_subfolder/src/interfaces/libpq/fe-connect.c
+    source_subfolder/src/interfaces/libpq/fe-exec.c
+    source_subfolder/src/interfaces/libpq/fe-lobj.c
+    source_subfolder/src/interfaces/libpq/fe-misc.c
+    source_subfolder/src/interfaces/libpq/fe-print.c
+    source_subfolder/src/interfaces/libpq/fe-protocol2.c
+    source_subfolder/src/interfaces/libpq/fe-protocol3.c
+    source_subfolder/src/interfaces/libpq/fe-secure.c
+    source_subfolder/src/interfaces/libpq/libpq-events.c
+    source_subfolder/src/interfaces/libpq/pqexpbuffer.c
+    source_subfolder/src/interfaces/libpq/libpq-dist.rc
+    source_subfolder/src/interfaces/libpq/pthread-win32.c
+    source_subfolder/src/interfaces/libpq/win32.c
+)
+
+set(pg_libpq_interface
+    source_subfolder/src/include/postgres_ext.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config_ext.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config.h
+    source_subfolder/src/interfaces/libpq/libpq-fe.h
+    source_subfolder/src/interfaces/libpq/libpq-events.h
+)
+
+set(pg_libpq_catalog_interface
+    source_subfolder/src/include/catalog/pg_type.h
+    source_subfolder/src/include/catalog/genbki.h
+)
+
+if (USE_OPENSSL)
+    list(APPEND pg_libpq_src
+        source_subfolder/src/interfaces/libpq/fe-secure-openssl.c
+        )
+    list(APPEND pg_backend_src
+        source_subfolder/src/common/sha2_openssl.c
+        )
+endif()
+
+if (USE_ZLIB)
+    list(APPEND pg_libpq_src
+            source_subfolder/contrib/pgcrypto/pgp-compress.c
+        )
+endif()
+
+add_library(libpq ${pg_port_src} ${pg_backend_src} ${pg_libpq_src})
+
+target_compile_definitions(libpq PRIVATE -DFRONTEND -DENABLE_THREAD_SAFETY ${OPENSSL_DEFINE} -D_CRT_SECURE_NO_WARNINGS)
+target_link_libraries(libpq PUBLIC ${CONAN_LIBS} ws2_32 secur32 advapi32 shell32 crypt32)
+
+target_include_directories(libpq PRIVATE source_subfolder/src/include source_subfolder/src/port ${CMAKE_BINARY_DIR}/include)
+set_target_properties(libpq PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+install(TARGETS libpq
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES ${pg_libpq_interface} DESTINATION include)
+install(DIRECTORY source_subfolder/src/include/libpq DESTINATION include)
+install(FILES ${pg_libpq_catalog_interface} DESTINATION include/catalog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 
 set(CMAKE_STATIC_LIBRARY_PREFIX)
 set(CMAKE_SHARED_LIBRARY_PREFIX)
-set(CMAKE_DEBUG_POSTFIX "d")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 file(WRITE source_subfolder/src/port/pg_config_paths.h "#define PGBINDIR \"${CONAN_CMAKE_MODULE_PATH}/bin\"\n")
@@ -105,7 +104,7 @@ endif()
 include_directories(source_subfolder/src/include/port/win32 source_subfolder/src/include/port/win32_msvc)
 
 set(pg_backend_src
-    source_subfolder/src/common/base64.c    
+    source_subfolder/src/common/base64.c
     source_subfolder/src/common/config_info.c
     source_subfolder/src/common/controldata_utils.c
     source_subfolder/src/common/fe_memutils.c
@@ -120,7 +119,7 @@ set(pg_backend_src
     source_subfolder/src/common/rmtree.c
     source_subfolder/src/common/saslprep.c
     source_subfolder/src/common/scram-common.c
-    source_subfolder/src/common/sha2.c    
+    source_subfolder/src/common/sha2.c
     source_subfolder/src/common/unicode_norm.c
     source_subfolder/src/common/username.c
     source_subfolder/src/common/wait_error.c
@@ -138,7 +137,7 @@ set(pg_libpq_src
     source_subfolder/src/interfaces/libpq/fe-print.c
     source_subfolder/src/interfaces/libpq/fe-protocol2.c
     source_subfolder/src/interfaces/libpq/fe-protocol3.c
-    source_subfolder/src/interfaces/libpq/fe-secure.c    
+    source_subfolder/src/interfaces/libpq/fe-secure.c
     source_subfolder/src/interfaces/libpq/libpq-events.c
     source_subfolder/src/interfaces/libpq/pqexpbuffer.c
     source_subfolder/src/interfaces/libpq/libpq-dist.rc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(pg_port_src
     source_subfolder/src/port/chklocale.c
     source_subfolder/src/port/crypt.c
     source_subfolder/src/port/dirent.c
+    source_subfolder/src/port/dirmod.c
     source_subfolder/src/port/erand48.c
     source_subfolder/src/port/fls.c
     source_subfolder/src/port/fseeko.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,11 +92,16 @@ set(pg_port_src
     source_subfolder/src/port/tar.c
     source_subfolder/src/port/thread.c
     source_subfolder/src/port/unsetenv.c
-    source_subfolder/src/port/win32env.c    
-    source_subfolder/src/port/win32error.c
+    source_subfolder/src/port/win32env.c
     source_subfolder/src/port/win32security.c
     source_subfolder/src/port/win32setlocale.c
 )
+
+if (${MSVC_VERSION} GREATER 1800)
+    list(APPEND pg_port_src
+         source_subfolder/src/port/win32error.c)
+endif()
+
 include_directories(source_subfolder/src/include/port/win32 source_subfolder/src/include/port/win32_msvc)
 
 set(pg_backend_src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ file(REMOVE
     source_subfolder/src/include/pg_config_os.h
 )
 
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define BLCKSZ 8192\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define XLOG_BLCKSZ 8192\n")
+
+
 configure_file(source_subfolder/src/include/pg_config.h.win32 include/pg_config.h)
 configure_file(source_subfolder/src/include/pg_config_ext.h.win32 include/pg_config_ext.h)
 configure_file(source_subfolder/src/include/port/win32.h include/pg_config_os.h)
@@ -68,7 +72,6 @@ set(pg_port_src
     source_subfolder/src/port/noblock.c
     source_subfolder/src/port/open.c
     source_subfolder/src/port/path.c
-    source_subfolder/src/port/pg_crc32c_armv8.c
     source_subfolder/src/port/pg_crc32c_armv8_choose.c
     source_subfolder/src/port/pg_crc32c_sb8.c
     source_subfolder/src/port/pg_crc32c_sse42.c
@@ -109,7 +112,6 @@ set(pg_backend_src
     source_subfolder/src/common/base64.c
     source_subfolder/src/common/config_info.c
     source_subfolder/src/common/controldata_utils.c
-    source_subfolder/src/common/exec.c
     source_subfolder/src/common/fe_memutils.c
     source_subfolder/src/common/file_perm.c
     source_subfolder/src/common/file_utils.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ set(pg_port_src
     source_subfolder/src/port/chklocale.c
     source_subfolder/src/port/crypt.c
     source_subfolder/src/port/dirent.c
-    source_subfolder/src/port/dirmod.c
     source_subfolder/src/port/erand48.c
     source_subfolder/src/port/fls.c
     source_subfolder/src/port/fseeko.c
@@ -93,6 +92,7 @@ set(pg_port_src
     source_subfolder/src/port/thread.c
     source_subfolder/src/port/unsetenv.c
     source_subfolder/src/port/win32env.c    
+    source_subfolder/src/port/win32error.c
     source_subfolder/src/port/win32security.c
     source_subfolder/src/port/win32setlocale.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,188 @@
+cmake_minimum_required(VERSION 3.5)
+project(libpq)
+
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif()
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+option(USE_OPENSSL "Build libpq with OpenSSL support" OFF)
+option(USE_ZLIB "Build libpq with zlib support" OFF)
+set(OPENSSL_DEFINE)
+if (USE_OPENSSL)
+    set(OPENSSL_DEFINE -DUSE_OPENSSL)
+endif()
+
+set(CMAKE_STATIC_LIBRARY_PREFIX)
+set(CMAKE_SHARED_LIBRARY_PREFIX)
+set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+file(WRITE source_subfolder/src/port/pg_config_paths.h "#define PGBINDIR \"${CONAN_CMAKE_MODULE_PATH}/bin\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PGBINDIR \"${CONAN_CMAKE_MODULE_PATH}/bin\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PGSHAREDIR \"${CONAN_CMAKE_MODULE_PATH}/share/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define SYSCONFDIR \"${CONAN_CMAKE_MODULE_PATH}/etc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define INCLUDEDIR \"${CONAN_CMAKE_MODULE_PATH}/include\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PKGINCLUDEDIR \"${CONAN_CMAKE_MODULE_PATH}/include/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define INCLUDEDIRSERVER \"${CONAN_CMAKE_MODULE_PATH}/include/postgresql/server\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define LIBDIR \"${CONAN_CMAKE_MODULE_PATH}/lib\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PKGLIBDIR \"${CONAN_CMAKE_MODULE_PATH}/lib/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define LOCALEDIR \"${CONAN_CMAKE_MODULE_PATH}/share/locale\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define DOCDIR \"${CONAN_CMAKE_MODULE_PATH}/share/doc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define HTMLDIR \"${CONAN_CMAKE_MODULE_PATH}/share/doc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define MANDIR \"${CONAN_CMAKE_MODULE_PATH}/share/man\"\n")
+
+file(REMOVE
+    source_subfolder/src/include/pg_config.h
+    source_subfolder/src/include/pg_config_ext.h
+    source_subfolder/src/include/pg_config_os.h
+)
+
+configure_file(source_subfolder/src/include/pg_config.h.win32 include/pg_config.h)
+configure_file(source_subfolder/src/include/pg_config_ext.h.win32 include/pg_config_ext.h)
+configure_file(source_subfolder/src/include/port/win32.h include/pg_config_os.h)
+
+file(WRITE ${CMAKE_BINARY_DIR}/include/pg_config_paths.h "#define SYSCONFDIR \"\"")
+
+
+set(pg_port_src
+    source_subfolder/src/port/chklocale.c
+    source_subfolder/src/port/crypt.c
+    source_subfolder/src/port/dirent.c
+    source_subfolder/src/port/dirmod.c
+    source_subfolder/src/port/erand48.c
+    source_subfolder/src/port/fls.c
+    source_subfolder/src/port/fseeko.c
+    source_subfolder/src/port/getaddrinfo.c
+    source_subfolder/src/port/getopt.c
+    source_subfolder/src/port/getopt_long.c
+    source_subfolder/src/port/getpeereid.c
+    source_subfolder/src/port/getrusage.c
+    source_subfolder/src/port/gettimeofday.c
+    source_subfolder/src/port/inet_aton.c
+    source_subfolder/src/port/inet_net_ntop.c
+    source_subfolder/src/port/isinf.c
+    source_subfolder/src/port/kill.c
+    source_subfolder/src/port/mkdtemp.c
+    source_subfolder/src/port/noblock.c
+    source_subfolder/src/port/open.c
+    source_subfolder/src/port/path.c
+    source_subfolder/src/port/pg_crc32c_choose.c
+    source_subfolder/src/port/pg_crc32c_sb8.c
+    source_subfolder/src/port/pg_crc32c_sse42.c
+    source_subfolder/src/port/pg_strong_random.c
+    source_subfolder/src/port/pgcheckdir.c
+    source_subfolder/src/port/pgmkdirp.c
+    source_subfolder/src/port/pgsleep.c
+    source_subfolder/src/port/pgstrcasecmp.c
+    source_subfolder/src/port/pqsignal.c
+    source_subfolder/src/port/qsort.c
+    source_subfolder/src/port/qsort_arg.c
+    source_subfolder/src/port/quotes.c
+    source_subfolder/src/port/random.c
+    source_subfolder/src/port/rint.c
+    source_subfolder/src/port/snprintf.c
+    source_subfolder/src/port/sprompt.c
+    source_subfolder/src/port/srandom.c
+    source_subfolder/src/port/strlcat.c
+    source_subfolder/src/port/strlcpy.c
+    source_subfolder/src/port/system.c
+    source_subfolder/src/port/tar.c
+    source_subfolder/src/port/thread.c
+    source_subfolder/src/port/unsetenv.c
+    source_subfolder/src/port/win32env.c    
+    source_subfolder/src/port/win32error.c
+    source_subfolder/src/port/win32security.c
+    source_subfolder/src/port/win32setlocale.c
+)
+include_directories(source_subfolder/src/include/port/win32 source_subfolder/src/include/port/win32_msvc)
+
+set(pg_backend_src
+    source_subfolder/src/common/base64.c    
+    source_subfolder/src/common/config_info.c
+    source_subfolder/src/common/controldata_utils.c
+    source_subfolder/src/common/fe_memutils.c
+    source_subfolder/src/common/file_utils.c
+    source_subfolder/src/common/ip.c
+    source_subfolder/src/common/keywords.c
+    source_subfolder/src/common/md5.c
+    source_subfolder/src/common/pg_lzcompress.c
+    source_subfolder/src/common/pgfnames.c
+    source_subfolder/src/common/psprintf.c
+    source_subfolder/src/common/restricted_token.c
+    source_subfolder/src/common/rmtree.c
+    source_subfolder/src/common/saslprep.c
+    source_subfolder/src/common/scram-common.c
+    source_subfolder/src/common/sha2.c    
+    source_subfolder/src/common/unicode_norm.c
+    source_subfolder/src/common/username.c
+    source_subfolder/src/common/wait_error.c
+    source_subfolder/src/backend/utils/mb/wchar.c
+    source_subfolder/src/backend/utils/mb/encnames.c
+)
+
+set(pg_libpq_src
+    source_subfolder/src/interfaces/libpq/fe-auth.c
+    source_subfolder/src/interfaces/libpq/fe-auth-scram.c
+    source_subfolder/src/interfaces/libpq/fe-connect.c
+    source_subfolder/src/interfaces/libpq/fe-exec.c
+    source_subfolder/src/interfaces/libpq/fe-lobj.c
+    source_subfolder/src/interfaces/libpq/fe-misc.c
+    source_subfolder/src/interfaces/libpq/fe-print.c
+    source_subfolder/src/interfaces/libpq/fe-protocol2.c
+    source_subfolder/src/interfaces/libpq/fe-protocol3.c
+    source_subfolder/src/interfaces/libpq/fe-secure.c    
+    source_subfolder/src/interfaces/libpq/libpq-events.c
+    source_subfolder/src/interfaces/libpq/pqexpbuffer.c
+    source_subfolder/src/interfaces/libpq/libpq-dist.rc
+    source_subfolder/src/interfaces/libpq/pthread-win32.c
+    source_subfolder/src/interfaces/libpq/win32.c
+)
+
+set(pg_libpq_interface
+    source_subfolder/src/include/postgres_ext.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config_ext.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config.h
+    source_subfolder/src/interfaces/libpq/libpq-fe.h
+    source_subfolder/src/interfaces/libpq/libpq-events.h
+)
+
+set(pg_libpq_catalog_interface
+    source_subfolder/src/include/catalog/pg_type.h
+    source_subfolder/src/include/catalog/genbki.h
+)
+
+if (USE_OPENSSL)
+    list(APPEND pg_libpq_src
+        source_subfolder/src/interfaces/libpq/fe-secure-openssl.c
+        )
+    list(APPEND pg_backend_src
+        source_subfolder/src/common/sha2_openssl.c
+        )
+endif()
+
+if (USE_ZLIB)
+    list(APPEND pg_libpq_src
+            source_subfolder/contrib/pgcrypto/pgp-compress.c
+        )
+endif()
+
+add_library(libpq ${pg_port_src} ${pg_backend_src} ${pg_libpq_src})
+
+target_compile_definitions(libpq PRIVATE -DFRONTEND -DENABLE_THREAD_SAFETY ${OPENSSL_DEFINE} -D_CRT_SECURE_NO_WARNINGS)
+target_link_libraries(libpq PUBLIC ${CONAN_LIBS} ws2_32 secur32 advapi32 shell32 crypt32)
+
+target_include_directories(libpq PRIVATE source_subfolder/src/include source_subfolder/src/port ${CMAKE_BINARY_DIR}/include)
+set_target_properties(libpq PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+install(TARGETS libpq
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES ${pg_libpq_interface} DESTINATION include)
+install(DIRECTORY source_subfolder/src/include/libpq DESTINATION include)
+install(FILES ${pg_libpq_catalog_interface} DESTINATION include/catalog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ file(REMOVE
     source_subfolder/src/include/pg_config_os.h
 )
 
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define BLCKSZ 8192\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define XLOG_BLCKSZ 8192\n")
+
+
 configure_file(source_subfolder/src/include/pg_config.h.win32 include/pg_config.h)
 configure_file(source_subfolder/src/include/pg_config_ext.h.win32 include/pg_config_ext.h)
 configure_file(source_subfolder/src/include/port/win32.h include/pg_config_os.h)
@@ -68,9 +72,10 @@ set(pg_port_src
     source_subfolder/src/port/noblock.c
     source_subfolder/src/port/open.c
     source_subfolder/src/port/path.c
-    source_subfolder/src/port/pg_crc32c_choose.c
+    source_subfolder/src/port/pg_crc32c_armv8_choose.c
     source_subfolder/src/port/pg_crc32c_sb8.c
     source_subfolder/src/port/pg_crc32c_sse42.c
+    source_subfolder/src/port/pg_crc32c_sse42_choose.c
     source_subfolder/src/port/pg_strong_random.c
     source_subfolder/src/port/pgcheckdir.c
     source_subfolder/src/port/pgmkdirp.c
@@ -108,6 +113,7 @@ set(pg_backend_src
     source_subfolder/src/common/config_info.c
     source_subfolder/src/common/controldata_utils.c
     source_subfolder/src/common/fe_memutils.c
+    source_subfolder/src/common/file_perm.c
     source_subfolder/src/common/file_utils.c
     source_subfolder/src/common/ip.c
     source_subfolder/src/common/keywords.c
@@ -138,6 +144,7 @@ set(pg_libpq_src
     source_subfolder/src/interfaces/libpq/fe-protocol2.c
     source_subfolder/src/interfaces/libpq/fe-protocol3.c
     source_subfolder/src/interfaces/libpq/fe-secure.c
+    source_subfolder/src/interfaces/libpq/fe-secure-common.c
     source_subfolder/src/interfaces/libpq/libpq-events.c
     source_subfolder/src/interfaces/libpq/pqexpbuffer.c
     source_subfolder/src/interfaces/libpq/libpq-dist.rc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,193 @@
+cmake_minimum_required(VERSION 3.5)
+project(libpq)
+
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif()
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+option(USE_OPENSSL "Build libpq with OpenSSL support" OFF)
+option(USE_ZLIB "Build libpq with zlib support" OFF)
+set(OPENSSL_DEFINE)
+if (USE_OPENSSL)
+    set(OPENSSL_DEFINE -DUSE_OPENSSL)
+endif()
+
+set(CMAKE_STATIC_LIBRARY_PREFIX)
+set(CMAKE_SHARED_LIBRARY_PREFIX)
+set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+file(WRITE source_subfolder/src/port/pg_config_paths.h "#define PGBINDIR \"${CONAN_CMAKE_MODULE_PATH}/bin\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PGBINDIR \"${CONAN_CMAKE_MODULE_PATH}/bin\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PGSHAREDIR \"${CONAN_CMAKE_MODULE_PATH}/share/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define SYSCONFDIR \"${CONAN_CMAKE_MODULE_PATH}/etc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define INCLUDEDIR \"${CONAN_CMAKE_MODULE_PATH}/include\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PKGINCLUDEDIR \"${CONAN_CMAKE_MODULE_PATH}/include/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define INCLUDEDIRSERVER \"${CONAN_CMAKE_MODULE_PATH}/include/postgresql/server\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define LIBDIR \"${CONAN_CMAKE_MODULE_PATH}/lib\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define PKGLIBDIR \"${CONAN_CMAKE_MODULE_PATH}/lib/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define LOCALEDIR \"${CONAN_CMAKE_MODULE_PATH}/share/locale\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define DOCDIR \"${CONAN_CMAKE_MODULE_PATH}/share/doc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define HTMLDIR \"${CONAN_CMAKE_MODULE_PATH}/share/doc/postgresql\"\n")
+file(APPEND source_subfolder/src/port/pg_config_paths.h "#define MANDIR \"${CONAN_CMAKE_MODULE_PATH}/share/man\"\n")
+
+file(REMOVE
+    source_subfolder/src/include/pg_config.h
+    source_subfolder/src/include/pg_config_ext.h
+    source_subfolder/src/include/pg_config_os.h
+)
+
+configure_file(source_subfolder/src/include/pg_config.h.win32 include/pg_config.h)
+configure_file(source_subfolder/src/include/pg_config_ext.h.win32 include/pg_config_ext.h)
+configure_file(source_subfolder/src/include/port/win32.h include/pg_config_os.h)
+
+file(WRITE ${CMAKE_BINARY_DIR}/include/pg_config_paths.h "#define SYSCONFDIR \"\"")
+
+
+set(pg_port_src
+    source_subfolder/src/port/chklocale.c
+    source_subfolder/src/port/crypt.c
+    source_subfolder/src/port/dirent.c
+    source_subfolder/src/port/dirmod.c
+    source_subfolder/src/port/erand48.c
+    source_subfolder/src/port/fls.c
+    source_subfolder/src/port/fseeko.c
+    source_subfolder/src/port/getaddrinfo.c
+    source_subfolder/src/port/getopt.c
+    source_subfolder/src/port/getopt_long.c
+    source_subfolder/src/port/getpeereid.c
+    source_subfolder/src/port/getrusage.c
+    source_subfolder/src/port/gettimeofday.c
+    source_subfolder/src/port/inet_aton.c
+    source_subfolder/src/port/inet_net_ntop.c
+    source_subfolder/src/port/isinf.c
+    source_subfolder/src/port/kill.c
+    source_subfolder/src/port/mkdtemp.c
+    source_subfolder/src/port/noblock.c
+    source_subfolder/src/port/open.c
+    source_subfolder/src/port/path.c
+    source_subfolder/src/port/pg_crc32c_choose.c
+    source_subfolder/src/port/pg_crc32c_sb8.c
+    source_subfolder/src/port/pg_crc32c_sse42.c
+    source_subfolder/src/port/pg_strong_random.c
+    source_subfolder/src/port/pgcheckdir.c
+    source_subfolder/src/port/pgmkdirp.c
+    source_subfolder/src/port/pgsleep.c
+    source_subfolder/src/port/pgstrcasecmp.c
+    source_subfolder/src/port/pqsignal.c
+    source_subfolder/src/port/qsort.c
+    source_subfolder/src/port/qsort_arg.c
+    source_subfolder/src/port/quotes.c
+    source_subfolder/src/port/random.c
+    source_subfolder/src/port/rint.c
+    source_subfolder/src/port/snprintf.c
+    source_subfolder/src/port/sprompt.c
+    source_subfolder/src/port/srandom.c
+    source_subfolder/src/port/strlcat.c
+    source_subfolder/src/port/strlcpy.c
+    source_subfolder/src/port/system.c
+    source_subfolder/src/port/tar.c
+    source_subfolder/src/port/thread.c
+    source_subfolder/src/port/unsetenv.c
+    source_subfolder/src/port/win32env.c
+    source_subfolder/src/port/win32security.c
+    source_subfolder/src/port/win32setlocale.c
+)
+
+if (${MSVC_VERSION} GREATER 1800)
+    list(APPEND pg_port_src
+         source_subfolder/src/port/win32error.c)
+endif()
+
+include_directories(source_subfolder/src/include/port/win32 source_subfolder/src/include/port/win32_msvc)
+
+set(pg_backend_src
+    source_subfolder/src/common/base64.c    
+    source_subfolder/src/common/config_info.c
+    source_subfolder/src/common/controldata_utils.c
+    source_subfolder/src/common/fe_memutils.c
+    source_subfolder/src/common/file_utils.c
+    source_subfolder/src/common/ip.c
+    source_subfolder/src/common/keywords.c
+    source_subfolder/src/common/md5.c
+    source_subfolder/src/common/pg_lzcompress.c
+    source_subfolder/src/common/pgfnames.c
+    source_subfolder/src/common/psprintf.c
+    source_subfolder/src/common/restricted_token.c
+    source_subfolder/src/common/rmtree.c
+    source_subfolder/src/common/saslprep.c
+    source_subfolder/src/common/scram-common.c
+    source_subfolder/src/common/sha2.c    
+    source_subfolder/src/common/unicode_norm.c
+    source_subfolder/src/common/username.c
+    source_subfolder/src/common/wait_error.c
+    source_subfolder/src/backend/utils/mb/wchar.c
+    source_subfolder/src/backend/utils/mb/encnames.c
+)
+
+set(pg_libpq_src
+    source_subfolder/src/interfaces/libpq/fe-auth.c
+    source_subfolder/src/interfaces/libpq/fe-auth-scram.c
+    source_subfolder/src/interfaces/libpq/fe-connect.c
+    source_subfolder/src/interfaces/libpq/fe-exec.c
+    source_subfolder/src/interfaces/libpq/fe-lobj.c
+    source_subfolder/src/interfaces/libpq/fe-misc.c
+    source_subfolder/src/interfaces/libpq/fe-print.c
+    source_subfolder/src/interfaces/libpq/fe-protocol2.c
+    source_subfolder/src/interfaces/libpq/fe-protocol3.c
+    source_subfolder/src/interfaces/libpq/fe-secure.c    
+    source_subfolder/src/interfaces/libpq/libpq-events.c
+    source_subfolder/src/interfaces/libpq/pqexpbuffer.c
+    source_subfolder/src/interfaces/libpq/libpq-dist.rc
+    source_subfolder/src/interfaces/libpq/pthread-win32.c
+    source_subfolder/src/interfaces/libpq/win32.c
+)
+
+set(pg_libpq_interface
+    source_subfolder/src/include/postgres_ext.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config_ext.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config.h
+    source_subfolder/src/interfaces/libpq/libpq-fe.h
+    source_subfolder/src/interfaces/libpq/libpq-events.h
+)
+
+set(pg_libpq_catalog_interface
+    source_subfolder/src/include/catalog/pg_type.h
+    source_subfolder/src/include/catalog/genbki.h
+)
+
+if (USE_OPENSSL)
+    list(APPEND pg_libpq_src
+        source_subfolder/src/interfaces/libpq/fe-secure-openssl.c
+        )
+    list(APPEND pg_backend_src
+        source_subfolder/src/common/sha2_openssl.c
+        )
+endif()
+
+if (USE_ZLIB)
+    list(APPEND pg_libpq_src
+            source_subfolder/contrib/pgcrypto/pgp-compress.c
+        )
+endif()
+
+add_library(libpq ${pg_port_src} ${pg_backend_src} ${pg_libpq_src})
+
+target_compile_definitions(libpq PRIVATE -DFRONTEND -DENABLE_THREAD_SAFETY ${OPENSSL_DEFINE} -D_CRT_SECURE_NO_WARNINGS)
+target_link_libraries(libpq PUBLIC ${CONAN_LIBS} ws2_32 secur32 advapi32 shell32 crypt32)
+
+target_include_directories(libpq PRIVATE source_subfolder/src/include source_subfolder/src/port ${CMAKE_BINARY_DIR}/include)
+set_target_properties(libpq PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+install(TARGETS libpq
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES ${pg_libpq_interface} DESTINATION include)
+install(DIRECTORY source_subfolder/src/include/libpq DESTINATION include)
+install(FILES ${pg_libpq_catalog_interface} DESTINATION include/catalog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,11 @@ set(pg_port_src
     source_subfolder/src/port/noblock.c
     source_subfolder/src/port/open.c
     source_subfolder/src/port/path.c
-    source_subfolder/src/port/pg_crc32c_choose.c
+    source_subfolder/src/port/pg_crc32c_armv8.c
+    source_subfolder/src/port/pg_crc32c_armv8_choose.c
     source_subfolder/src/port/pg_crc32c_sb8.c
     source_subfolder/src/port/pg_crc32c_sse42.c
+    source_subfolder/src/port/pg_crc32c_sse42_choose.c
     source_subfolder/src/port/pg_strong_random.c
     source_subfolder/src/port/pgcheckdir.c
     source_subfolder/src/port/pgmkdirp.c
@@ -107,7 +109,9 @@ set(pg_backend_src
     source_subfolder/src/common/base64.c
     source_subfolder/src/common/config_info.c
     source_subfolder/src/common/controldata_utils.c
+    source_subfolder/src/common/exec.c
     source_subfolder/src/common/fe_memutils.c
+    source_subfolder/src/common/file_perm.c
     source_subfolder/src/common/file_utils.c
     source_subfolder/src/common/ip.c
     source_subfolder/src/common/keywords.c
@@ -138,6 +142,7 @@ set(pg_libpq_src
     source_subfolder/src/interfaces/libpq/fe-protocol2.c
     source_subfolder/src/interfaces/libpq/fe-protocol3.c
     source_subfolder/src/interfaces/libpq/fe-secure.c
+    source_subfolder/src/interfaces/libpq/fe-secure-common.c
     source_subfolder/src/interfaces/libpq/libpq-events.c
     source_subfolder/src/interfaces/libpq/pqexpbuffer.c
     source_subfolder/src/interfaces/libpq/libpq-dist.rc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ set(pg_port_src
     source_subfolder/src/port/thread.c
     source_subfolder/src/port/unsetenv.c
     source_subfolder/src/port/win32env.c    
-    source_subfolder/src/port/win32error.c
     source_subfolder/src/port/win32security.c
     source_subfolder/src/port/win32setlocale.c
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,12 @@ environment:
     PYTHON_HOME: "C:\\Python37"
 
     matrix:
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
         - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix'
           CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
         - MINGW_CONFIGURATIONS: '5@x86_64@seh@posix'
@@ -12,12 +18,6 @@ environment:
           CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
         - MINGW_CONFIGURATIONS: '7@x86_64@seh@posix'
           CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,22 @@ environment:
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x8664
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86
         - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix'
           CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
         - MINGW_CONFIGURATIONS: '5@x86_64@seh@posix'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,24 @@ environment:
     PYTHON_HOME: "C:\\Python37"
 
     matrix:
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86
         - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix'
           CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
         - MINGW_CONFIGURATIONS: '5@x86_64@seh@posix'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
           CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
-          CONAN_ARCHS: x8664
+          CONAN_ARCHS: x86
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_ARCHS: x86_64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,12 @@ environment:
           CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
         - MINGW_CONFIGURATIONS: '7@x86_64@seh@posix'
           CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/conan-libpq.iml
+++ b/conan-libpq.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ import os
 
 class LibpqConan(ConanFile):
     name = "libpq"
-    version = "11.3"
+    version = "11.4"
     description = "The library used by all the standard PostgreSQL tools."
     topics = ("conan", "libpq", "postgresql", "database", "db")
     url = "https://github.com/bincrafters/conan-libpq"
@@ -41,11 +41,11 @@ class LibpqConan(ConanFile):
         if self.options.with_zlib:
             self.requires.add("zlib/1.2.11@conan/stable")
         if self.options.with_openssl:
-            self.requires.add("OpenSSL/1.0.2r@conan/stable")
+            self.requires.add("OpenSSL/1.0.2s@conan/stable")
 
     def source(self):
         source_url = "https://ftp.postgresql.org/pub/source"
-        sha256 = "2a9ff3659e327a4369929478200046942710fd6bc25fe56c72d6b01ee8b1974a"
+        sha256 = "2043ab71f2a435a9e77b4419f804525a0b9ec1ef37d19c1c2e4013dc1cae01a7"
         tools.get("{0}/v{1}/postgresql-{2}.tar.gz".format(source_url, self.version, self.version), sha256=sha256)
         extracted_dir = "postgresql-" + self.version
         os.rename(extracted_dir, self._source_subfolder)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans import ConanFile, AutoToolsBuildEnvironment, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -16,6 +15,7 @@ class LibpqConan(ConanFile):
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "PostgreSQL"
     exports = ["LICENSE.md"]
+    exports_sources = ["CMakeLists.txt"]
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -23,25 +23,31 @@ class LibpqConan(ConanFile):
         "with_zlib": [True, False],
         "with_openssl": [True, False]}
     default_options = {'shared': False, 'fPIC': True, 'with_zlib': False, 'with_openssl': False}
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = None
+    generators = "cmake"
     _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return os.path.join(self.build_folder, "output")
 
     def config_options(self):
         if self.settings.os == 'Windows':
-            del self.options.fPIC
-            del self.options.shared
+            del self.options.fPIC            
 
     def configure(self):
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("Visual Studio is not supported yet.")
         del self.settings.compiler.libcxx
+        if self.settings.os == 'Windows' and self.options.shared:
+            raise ConanInvalidConfiguration("libpq can not be built as shared library on Windows")
 
     def requirements(self):
         if self.options.with_zlib:
             self.requires.add("zlib/1.2.11@conan/stable")
         if self.options.with_openssl:
-            self.requires.add("OpenSSL/1.0.2r@conan/stable")
+            self.requires.add("OpenSSL/1.0.2s@conan/stable")
 
     def source(self):
         source_url = "https://ftp.postgresql.org/pub/source"
@@ -53,7 +59,6 @@ class LibpqConan(ConanFile):
     def _configure_autotools(self):
         if not self._autotools:
             self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-            self._build_subfolder = os.path.join(self.build_folder, "output")
             args = ['--without-readline']
             args.append('--with-zlib' if self.options.with_zlib else '--without-zlib')
             args.append('--with-openssl' if self.options.with_openssl else '--without-openssl')
@@ -61,35 +66,50 @@ class LibpqConan(ConanFile):
                 self._autotools.configure(args=args)
         return self._autotools
 
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
     def build(self):
-        autotools = self._configure_autotools()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-            autotools.make()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-            autotools.make()
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            cmake = self._configure_cmake()
+            cmake.definitions["USE_OPENSSL"] = self.options.with_openssl
+            cmake.definitions["USE_ZLIB"] = self.options.with_zlib
+            cmake.build()
+        else:
+            autotools = self._configure_autotools()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.make()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.make()
 
     def package(self):
         self.copy(pattern="COPYRIGHT", dst="licenses", src=self._source_subfolder)
-        autotools = self._configure_autotools()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-            autotools.install()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-            autotools.install()
-        self.copy(pattern="*.h", dst="include", src=os.path.join(self._build_subfolder, "include"))
-        self.copy(pattern="postgres_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
-        self.copy(pattern="pg_config_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
-        if self.settings.os == "Linux":
-            pattern = "*.so*" if self.options.shared else "*.a"
-        elif self.settings.os == "Macos":
-            pattern = "*.dylib" if self.options.shared else "*.a"
-        elif self.settings.os == "Windows":
-            pattern = "*.a"
-            self.copy(pattern="*.dll", dst="bin", src=os.path.join(self._build_subfolder, "bin"))
-        self.copy(pattern=pattern, dst="lib", src=os.path.join(self._build_subfolder, "lib"))
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            cmake = self._configure_cmake()
+            cmake.install()
+        else:
+            autotools = self._configure_autotools()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.install()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.install()
+            self.copy(pattern="*.h", dst="include", src=os.path.join(self._build_subfolder, "include"))
+            self.copy(pattern="postgres_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
+            self.copy(pattern="pg_config_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
+            if self.settings.os == "Linux":
+                pattern = "*.so*" if self.options.shared else "*.a"
+            elif self.settings.os == "Macos":
+                pattern = "*.dylib" if self.options.shared else "*.a"
+            elif self.settings.os == "Windows":
+                pattern = "*.a"
+                self.copy(pattern="*.dll", dst="bin", src=os.path.join(self._build_subfolder, "bin"))
+            self.copy(pattern=pattern, dst="lib", src=os.path.join(self._build_subfolder, "lib"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
         elif self.settings.os == "Windows":
-            self.cpp_info.libs.append("ws2_32")
+            self.cpp_info.libs.extend(["ws2_32", "secur32", "advapi32", "shell32", "crypt32"])

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans import ConanFile, AutoToolsBuildEnvironment, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -16,6 +15,7 @@ class LibpqConan(ConanFile):
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "PostgreSQL"
     exports = ["LICENSE.md"]
+    exports_sources = ["CMakeLists.txt"]
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -23,19 +23,25 @@ class LibpqConan(ConanFile):
         "with_zlib": [True, False],
         "with_openssl": [True, False]}
     default_options = {'shared': False, 'fPIC': True, 'with_zlib': False, 'with_openssl': False}
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = None
+    generators = "cmake"
     _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return os.path.join(self.build_folder, "output")
 
     def config_options(self):
         if self.settings.os == 'Windows':
             del self.options.fPIC
-            del self.options.shared
 
     def configure(self):
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("Visual Studio is not supported yet.")
         del self.settings.compiler.libcxx
+        if self.settings.os == 'Windows' and self.options.shared:
+            raise ConanInvalidConfiguration("libpq can not be built as shared library on Windows")
 
     def requirements(self):
         if self.options.with_zlib:
@@ -53,7 +59,6 @@ class LibpqConan(ConanFile):
     def _configure_autotools(self):
         if not self._autotools:
             self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-            self._build_subfolder = os.path.join(self.build_folder, "output")
             args = ['--without-readline']
             args.append('--with-zlib' if self.options.with_zlib else '--without-zlib')
             args.append('--with-openssl' if self.options.with_openssl else '--without-openssl')
@@ -61,22 +66,37 @@ class LibpqConan(ConanFile):
                 self._autotools.configure(args=args)
         return self._autotools
 
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
     def build(self):
-        autotools = self._configure_autotools()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-            autotools.make()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-            autotools.make()
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            cmake = self._configure_cmake()
+            cmake.definitions["USE_OPENSSL"] = self.options.with_openssl
+            cmake.definitions["USE_ZLIB"] = self.options.with_zlib
+            cmake.build()
+        else:
+            autotools = self._configure_autotools()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.make()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.make()
 
     def package(self):
         self.copy(pattern="COPYRIGHT", dst="licenses", src=self._source_subfolder)
-        autotools = self._configure_autotools()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-            autotools.install()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-            autotools.install()
-        self.copy(pattern="*.h", dst="include", src=os.path.join(self._build_subfolder, "include"))
-        self.copy(pattern="*.h", dst=os.path.join("include", "catalog"), src=os.path.join(self._source_subfolder, "src", "include", "catalog"))
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            cmake = self._configure_cmake()
+            cmake.install()
+        else:
+            autotools = self._configure_autotools()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.install()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.install()
+            self.copy(pattern="*.h", dst="include", src=os.path.join(self._build_subfolder, "include"))
+            self.copy(pattern="*.h", dst=os.path.join("include", "catalog"), src=os.path.join(self._source_subfolder, "src", "include", "catalog"))
         self.copy(pattern="*.h", dst=os.path.join("include", "catalog"), src=os.path.join(self._source_subfolder, "src", "backend", "catalog"))
         self.copy(pattern="postgres_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
         self.copy(pattern="pg_config_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
@@ -95,4 +115,4 @@ class LibpqConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
         elif self.settings.os == "Windows":
-            self.cpp_info.libs.append("ws2_32")
+            self.cpp_info.libs.extend(["ws2_32", "secur32", "advapi32", "shell32", "crypt32"])

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,9 +23,16 @@ class LibpqConan(ConanFile):
         "with_zlib": [True, False],
         "with_openssl": [True, False]}
     default_options = {'shared': False, 'fPIC': True, 'with_zlib': False, 'with_openssl': False}
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = None
     _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return os.path.join(self.build_folder, "output")
+
 
     def config_options(self):
         if self.settings.os == 'Windows':
@@ -53,7 +60,6 @@ class LibpqConan(ConanFile):
     def _configure_autotools(self):
         if not self._autotools:
             self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-            self._build_subfolder = os.path.join(self.build_folder, "output")
             args = ['--without-readline']
             args.append('--with-zlib' if self.options.with_zlib else '--without-zlib')
             args.append('--with-openssl' if self.options.with_openssl else '--without-openssl')

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans import ConanFile, AutoToolsBuildEnvironment, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -16,6 +15,7 @@ class LibpqConan(ConanFile):
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "PostgreSQL"
     exports = ["LICENSE.md"]
+    exports_sources = ["CMakeLists.txt"]
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -23,6 +23,7 @@ class LibpqConan(ConanFile):
         "with_zlib": [True, False],
         "with_openssl": [True, False]}
     default_options = {'shared': False, 'fPIC': True, 'with_zlib': False, 'with_openssl': False}
+    generators = "cmake"
     _autotools = None
 
     @property
@@ -33,22 +34,20 @@ class LibpqConan(ConanFile):
     def _build_subfolder(self):
         return os.path.join(self.build_folder, "output")
 
-
     def config_options(self):
         if self.settings.os == 'Windows':
-            del self.options.fPIC
-            del self.options.shared
+            del self.options.fPIC            
 
     def configure(self):
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("Visual Studio is not supported yet.")
         del self.settings.compiler.libcxx
+        if self.settings.os == 'Windows' and self.options.shared:
+            raise ConanInvalidConfiguration("libpq can not be built as shared library on Windows")
 
     def requirements(self):
         if self.options.with_zlib:
             self.requires.add("zlib/1.2.11@conan/stable")
         if self.options.with_openssl:
-            self.requires.add("OpenSSL/1.0.2r@conan/stable")
+            self.requires.add("OpenSSL/1.0.2s@conan/stable")
 
     def source(self):
         source_url = "https://ftp.postgresql.org/pub/source"
@@ -67,35 +66,50 @@ class LibpqConan(ConanFile):
                 self._autotools.configure(args=args)
         return self._autotools
 
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
     def build(self):
-        autotools = self._configure_autotools()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-            autotools.make()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-            autotools.make()
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            cmake = self._configure_cmake()
+            cmake.definitions["USE_OPENSSL"] = self.options.with_openssl
+            cmake.definitions["USE_ZLIB"] = self.options.with_zlib
+            cmake.build()
+        else:
+            autotools = self._configure_autotools()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.make()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.make()
 
     def package(self):
         self.copy(pattern="COPYRIGHT", dst="licenses", src=self._source_subfolder)
-        autotools = self._configure_autotools()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-            autotools.install()
-        with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-            autotools.install()
-        self.copy(pattern="*.h", dst="include", src=os.path.join(self._build_subfolder, "include"))
-        self.copy(pattern="postgres_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
-        self.copy(pattern="pg_config_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
-        if self.settings.os == "Linux":
-            pattern = "*.so*" if self.options.shared else "*.a"
-        elif self.settings.os == "Macos":
-            pattern = "*.dylib" if self.options.shared else "*.a"
-        elif self.settings.os == "Windows":
-            pattern = "*.a"
-            self.copy(pattern="*.dll", dst="bin", src=os.path.join(self._build_subfolder, "bin"))
-        self.copy(pattern=pattern, dst="lib", src=os.path.join(self._build_subfolder, "lib"))
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            cmake = self._configure_cmake()
+            cmake.install()
+        else:
+            autotools = self._configure_autotools()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.install()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.install()
+            self.copy(pattern="*.h", dst="include", src=os.path.join(self._build_subfolder, "include"))
+            self.copy(pattern="postgres_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
+            self.copy(pattern="pg_config_ext.h", dst="include", src=os.path.join(self._source_subfolder, "src", "include"))
+            if self.settings.os == "Linux":
+                pattern = "*.so*" if self.options.shared else "*.a"
+            elif self.settings.os == "Macos":
+                pattern = "*.dylib" if self.options.shared else "*.a"
+            elif self.settings.os == "Windows":
+                pattern = "*.a"
+                self.copy(pattern="*.dll", dst="bin", src=os.path.join(self._build_subfolder, "bin"))
+            self.copy(pattern=pattern, dst="lib", src=os.path.join(self._build_subfolder, "lib"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
         elif self.settings.os == "Windows":
-            self.cpp_info.libs.append("ws2_32")
+            self.cpp_info.libs.extend(["ws2_32", "secur32", "advapi32", "shell32", "crypt32"])


### PR DESCRIPTION
This pull request (which should be against a new branch 11.4) updates the library to libpq version 11.4, updating then downstream dependencies (more specific: OpenSSL) while doing so. I consider this worth PRing, as [the changelog](https://www.postgresql.org/docs/11/release-11-4.html) states 11.4 fixes a security vulnerability that affects both the server and libpq.