### PR TITLE
Changes to use original top-level makefile

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -84,13 +84,7 @@ class LibpqConan(ConanFile):
             cmake.build()
         else:
             autotools = self._configure_autotools()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-                autotools.make()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "include")):
-                autotools.make()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-                autotools.make()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "bin", "pg_config")):
+            with tools.chdir(self._source_subfolder):
                 autotools.make()
 
     def package(self):
@@ -100,13 +94,7 @@ class LibpqConan(ConanFile):
             cmake.install()
         else:
             autotools = self._configure_autotools()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
-                autotools.install()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "include")):
-                autotools.install()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
-                autotools.install()
-            with tools.chdir(os.path.join(self._source_subfolder, "src", "bin", "pg_config")):
+            with tools.chdir(self._source_subfolder):
                 autotools.install()
             tools.rmdir(os.path.join(self.package_folder, "include", "postgresql", "server"))
             self.copy(pattern="*.h", dst=os.path.join("include", "catalog"), src=os.path.join(self._source_subfolder, "src", "include", "catalog"))

--- a/conanfile.py
+++ b/conanfile.py
@@ -84,7 +84,15 @@ class LibpqConan(ConanFile):
             cmake.build()
         else:
             autotools = self._configure_autotools()
-            with tools.chdir(self._source_subfolder):
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "backend")):
+                autotools.make(target="generated-headers")
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.make()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "include")):
+                autotools.make()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.make()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "bin", "pg_config")):
                 autotools.make()
 
     def package(self):
@@ -94,7 +102,13 @@ class LibpqConan(ConanFile):
             cmake.install()
         else:
             autotools = self._configure_autotools()
-            with tools.chdir(self._source_subfolder):
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
+                autotools.install()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "include")):
+                autotools.install()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "interfaces", "libpq")):
+                autotools.install()
+            with tools.chdir(os.path.join(self._source_subfolder, "src", "bin", "pg_config")):
                 autotools.install()
             tools.rmdir(os.path.join(self.package_folder, "include", "postgresql", "server"))
             self.copy(pattern="*.h", dst=os.path.join("include", "catalog"), src=os.path.join(self._source_subfolder, "src", "include", "catalog"))


### PR DESCRIPTION
On some systems this gave errors (similar to https://www.postgresql.org/message-id/15407-7b64e5de97dedc5e%40postgresql.org . This change involves more than doubling build time, but it should solve errors such as https://github.com/bincrafters/community/issues/912

